### PR TITLE
Fix repository in workflow used to delete old workflow runs

### DIFF
--- a/.github/workflows/delete-old-workflows-run.yaml
+++ b/.github/workflows/delete-old-workflows-run.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Delete old workflow runs
         uses: MajorScruffy/delete-old-workflow-runs@v0.3.0
         with:
-          repository: mapfish/mapfish-print # replace this with your own repository
+          repository: ${{ env.GITHUB_REPOSITORY }}
           older-than-seconds: 43200000 # 500 days
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Update dependency bootstrap to v5.2.2
- Regenerate the expected templates
- Add workflow to delete old workflow runs
- Fix repository in workflow used to delete old workflow runs
