### PR TITLE
More generic version

### DIFF
--- a/templates/redirect-config.yaml
+++ b/templates/redirect-config.yaml
@@ -6,7 +6,12 @@ metadata:
   {{- include "common.metadata" ( dict "root" . "service" .Values.server.redirect ) | nindent 2 }}
 spec:
   matchLabels:
+  {{- if eq $.Values.version "1" }}
     mutualize-redirect-hosts: 'true'
+  {{- else }}
+    mutualize-redirect-hosts: 'true'
+    mutualize-version: {{ $.Values.version | quote }}
+  {{- end }}
   configmapName: hosts.yaml
   property: sources
 {{- end }}

--- a/templates/shared-config-config.yaml
+++ b/templates/shared-config-config.yaml
@@ -6,8 +6,12 @@ metadata:
   {{- include "common.metadata" ( dict "root" . "service" .Values.server.sharedConfig ) | nindent 2 }}
 spec:
   matchLabels:
+  {{- if eq $.Values.version "1" }}
+    mutualize-sharedconfig: 'true'
+  {{- else }}
     mutualize-config: 'true'
     mutualize-version: {{ $.Values.version | quote }}
+  {{- end }}
   property: sources
   configmapName: config.yaml
 {{- end }}

--- a/templates/sharedconfig.yaml
+++ b/templates/sharedconfig.yaml
@@ -107,19 +107,24 @@ spec:
         {{- end }}
     {{- end }}
     {{- end }}
-{{- range $host := $value.hosts }}
+{{- range $host_name, $host := $value.hosts }}
 ---
-{{- $used_name := printf "%s-%s" $name $host.name }}
+{{- $used_name := printf "%s-%s" $name $host_name }}
 apiVersion: camptocamp.com/v3
 kind: SharedConfigSource{{ $.Values.environment | title }}
 metadata:
   name: {{ include "common.fullname" ( dict "root" $ "service" $.Values "serviceName" $used_name ) }}
   labels: {{ include "common.labels" ( dict "root" $ "service" $.Values "serviceName" $used_name ) | nindent 4 }}
+  {{- if eq $.Values.version "1" }}
     mutualize-tilecloudchain-hosts: 'true'
+  {{- else }}
+    mutualize-tilecloudchain-hosts: 'true'
+    mutualize-version: {{ $.Values.version | quote }}
+  {{- end }}
 spec:
-  name: {{ $name }}-{{ $host.name }}
+  name: {{ $name }}-{{ $host_name }}
   content:
-    {{ $host.host }}: /etc/tilecloudchain-configs/{{ $name }}/config.yaml
+    {{ $host }}: /etc/tilecloudchain-configs/{{ $name }}/config.yaml
 {{- end }}
 {{- end }}
 {{- end }}
@@ -131,12 +136,15 @@ kind: SharedConfigSource{{ $.Values.environment | title }}
 metadata:
   name: {{ include "common.fullname" ( dict "root" $ "service" $.Values "serviceName" "redirect" ) }}
   {{- include "common.metadata" ( dict "root" $ "service" $.Values "serviceName" "redirect"  ) | nindent 2 }}
+  {{- if eq $.Values.version "1" }}
     mutualize-redirect-hosts: 'true'
+  {{- else }}
+    mutualize-redirect-hosts: 'true'
+    mutualize-version: {{ $.Values.version | quote }}
+  {{- end }}
 spec:
   name: {{ include "common.fullname" ( dict "root" $ "service" $.Values "serviceName" "redirect" ) }}
   content:
-{{- range $host := .hosts }}
-   {{ $host }}: {{ $host }}
-{{- end }}
+    {{- toYaml .hosts | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/templates/tilecloudchain-config-hosts.yaml
+++ b/templates/tilecloudchain-config-hosts.yaml
@@ -6,7 +6,12 @@ metadata:
   {{- include "common.metadata" ( dict "root" . "service" .Values.server.tilecloudchain ) | nindent 2 }}
 spec:
   matchLabels:
+  {{- if eq $.Values.version "1" }}
     mutualize-tilecloudchain-hosts: 'true'
+  {{- else }}
+    mutualize-tilecloudchain-hosts: 'true'
+    mutualize-version: {{ $.Values.version | quote }}
+  {{- end }}
   configmapName: hosts.yaml
   property: sources
 {{- end }}

--- a/tests/expected-server.yaml
+++ b/tests/expected-server.yaml
@@ -184,6 +184,7 @@ metadata:
 spec:
   matchLabels:
     mutualize-redirect-hosts: 'true'
+    mutualize-version: "2"
   configmapName: hosts.yaml
   property: sources
 ---
@@ -221,5 +222,6 @@ metadata:
 spec:
   matchLabels:
     mutualize-tilecloudchain-hosts: 'true'
+    mutualize-version: "2"
   configmapName: hosts.yaml
   property: sources

--- a/tests/expected.yaml
+++ b/tests/expected.yaml
@@ -335,6 +335,7 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/component: tilecloudchain-example-host1
     mutualize-tilecloudchain-hosts: 'true'
+    mutualize-version: "2"
 spec:
   name: tilecloudchain-example-host1
   content:
@@ -353,6 +354,7 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/component: tilecloudchain-example-host2
     mutualize-tilecloudchain-hosts: 'true'
+    mutualize-version: "2"
 spec:
   name: tilecloudchain-example-host2
   content:
@@ -408,6 +410,7 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/component: tilecloudchain-multi-example-host3
     mutualize-tilecloudchain-hosts: 'true'
+    mutualize-version: "2"
 spec:
   name: tilecloudchain-multi-example-host3
   content:
@@ -426,9 +429,10 @@ metadata:
     app.kubernetes.io/instance: test
     app.kubernetes.io/component: redirect
     mutualize-redirect-hosts: 'true'
+    mutualize-version: "2"
 spec:
   name: test-mutualize-redirect
   content:
-   host1.example.com: host1.example.com
-   host2.example.com: host2.example.com
-   host3.example.com: host3.example.com
+    host1: host1.example.com
+    host2: host2.example.com
+    host3: host3.example.com

--- a/tests/values.yaml
+++ b/tests/values.yaml
@@ -25,10 +25,8 @@ config:
         branch: tilecloudchain-example
         sub_dir: examples/src/test/resources/examples
         hosts:
-          - host: host1.example.com
-            name: host1
-          - host: host2.example.com
-            name: host2
+          host1: host1.example.com
+          host2: host2.example.com
       tilecloudchain-multi-example:
         repo: tilecloudchain/repo-multi
         branch: tilecloudchain-multi
@@ -41,13 +39,12 @@ config:
             data:
               ENV: e2
         hosts:
-          - host: host3.example.com
-            name: host3
+          host3: host3.example.com
   redirectConfigs:
     hosts:
-      - host1.example.com
-      - host2.example.com
-      - host3.example.com
+      host1: host1.example.com
+      host2: host2.example.com
+      host3: host3.example.com
 
   sharedConfigs:
     examples:

--- a/values.md
+++ b/values.md
@@ -66,10 +66,12 @@
       - **Additional properties**
         - **All of**
           - : Refer to _[#/definitions/source](#definitions/source)_.
-          -
+          - _object_
+            - **`hosts`** _(object)_: The hosts to use by name. Can contain additional properties.
+              - **Additional properties** _(string)_: The host to use.
   - **`redirectConfigs`** _(object)_: The redirect configuration.
-    - **`hosts`** _(array)_: The hosts to use.
-      - **Items** _(string)_
+    - **`hosts`** _(object)_: The hosts to use by name. Can contain additional properties.
+      - **Additional properties** _(string)_: The hosts to use.
   - **`sharedConfigs`** _(object)_: Can contain additional properties.
     - **Additional properties**
   - **`webhooks`** _(object)_: Additional WebHooks used by the GitHub WebHook operator to create WebHook in the GitHub repository of the related project. Cannot contain additional properties.
@@ -102,6 +104,14 @@
 - <a id="definitions/annotations"></a>**`annotations`** _(object)_: [helm-common] Pod annotations. Can contain additional properties.
   - **Additional properties** _(string)_
 - <a id="definitions/serviceName"></a>**`serviceName`** _(string)_: [helm-common] The name of the service (not Kubernetes service), this will postfix the name.
-- <a id="definitions/source"></a>**`source`**
+- <a id="definitions/source"></a>**`source`** _(object)_
+  - **`repo`** _(string)_: The repository to use in format <org>/<repo>.
+  - **`branch`** _(string)_: The branch to clone.
+  - **`sub_dir`** _(string)_: The directory to clone.
+  - **`template_engines`** _(array)_: The template engines configuration.
+    - **Items** _(object)_: Cannot contain additional properties.
+      - **`dest_sub_dir`** _(string)_: The destination sub directory.
+      - **`data`** _(object)_: The environment variable used to interpret this configuration. Can contain additional properties.
+        - **Additional properties** _(string)_
 - <a id="definitions/sources"></a>**`sources`** _(object)_: The sources configuration. Can contain additional properties.
   - **Additional properties**: Refer to _[#/definitions/source](#definitions/source)_.

--- a/values.schema.json
+++ b/values.schema.json
@@ -40,34 +40,37 @@
       "description": "[helm-common] The name of the service (not Kubernetes service), this will postfix the name"
     },
     "source": {
-      "repo": {
-        "type": "string",
-        "description": "The repository to use in format <org>/<repo>"
-      },
-      "branch": {
-        "type": "string",
-        "description": "The branch to clone"
-      },
-      "sub_dir": {
-        "type": "string",
-        "description": "The directory to clone"
-      },
-      "template_engines": {
-        "type": "array",
-        "description": "The template engines configuration",
-        "items": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "dest_sub_dir": {
-              "type": "string",
-              "description": "The destination sub directory"
-            },
-            "data": {
-              "type": "object",
-              "description": "The environment variable used to interpret this configuration",
-              "additionalProperties": {
-                "type": "string"
+      "type": "object",
+      "properties": {
+        "repo": {
+          "type": "string",
+          "description": "The repository to use in format <org>/<repo>"
+        },
+        "branch": {
+          "type": "string",
+          "description": "The branch to clone"
+        },
+        "sub_dir": {
+          "type": "string",
+          "description": "The directory to clone"
+        },
+        "template_engines": {
+          "type": "array",
+          "description": "The template engines configuration",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "dest_sub_dir": {
+                "type": "string",
+                "description": "The destination sub directory"
+              },
+              "data": {
+                "type": "object",
+                "description": "The environment variable used to interpret this configuration",
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
             }
           }
@@ -322,21 +325,14 @@
                     "$ref": "#/definitions/source"
                   },
                   {
-                    "hosts": {
-                      "type": "array",
-                      "description": "The hosts to use",
-                      "items": {
+                    "type": "object",
+                    "properties": {
+                      "hosts": {
                         "type": "object",
-                        "additionalProperties": false,
-                        "properties": {
-                          "host": {
-                            "type": "string",
-                            "description": "The host to use"
-                          },
-                          "name": {
-                            "type": "string",
-                            "description": "The name of the host"
-                          }
+                        "description": "The hosts to use by name",
+                        "additionalProperties": {
+                          "type": "string",
+                          "description": "The host to use"
                         }
                       }
                     }
@@ -351,10 +347,11 @@
           "description": "The redirect configuration",
           "properties": {
             "hosts": {
-              "type": "array",
-              "description": "The hosts to use",
-              "items": {
-                "type": "string"
+              "type": "object",
+              "description": "The hosts to use by name",
+              "additionalProperties": {
+                "type": "string",
+                "description": "The hosts to use"
               }
             }
           }


### PR DESCRIPTION
- TielCloudChain and redirect config hosts add object
- Add missing `mutualize-version: "2"` label