### PR TITLE
Add workflow-level permissions to GitHub Actions

### DIFF
--- a/.github/workflows/pull-request-automation.yaml
+++ b/.github/workflows/pull-request-automation.yaml
@@ -5,6 +5,9 @@ on:
     types:
       - opened
       - reopened
+permissions:
+  contents: read
+
 jobs:
   auto-merge:
     name: Auto reviews pull requests from bots


### PR DESCRIPTION
## Summary
Add top-level `permissions: contents: read` to `pull-request-automation.yaml` workflow to enforce least-privilege GitHub Actions permissions.

## Context
- GitHub Actions workflows without explicit top-level permissions default to broad permissions
- The job already has `permissions: pull-requests: write` scoped correctly
- Adding `contents: read` at workflow level restricts the default token scope